### PR TITLE
Revert "chore(deps-dev): bump @types/node from 22.19.7 to 25.1.0 in t…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@types/better-sqlite3": "^7.6.12",
-        "@types/node": "^25.1.0",
+        "@types/node": "^24.10.9",
         "@types/node-cron": "^3.0.11",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
@@ -755,9 +755,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
-      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+      "version": "24.10.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
+      "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@types/better-sqlite3": "^7.6.12",
-    "@types/node": "^25.1.0",
+    "@types/node": "^24.10.9",
     "@types/node-cron": "^3.0.11",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
…he dev-dependencies group"

## What does this PR do?

Brief description of the change.

## Why?

Context on motivation — link to issue if applicable.

## How to test

Steps to verify this works:
1. `npm run build`
2. ...

## Checklist

- [ ] `npm run build` passes
- [ ] Tested manually via CLI or OpenClaw
- [ ] Updated docs if behavior changed
