### PR TITLE
Bug: use release PR instead of direct push to protected main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,12 @@ on:
 jobs:
   release:
     # Skip if this is a release commit (prevents infinite loop)
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    if: "!contains(github.event.head_commit.message, 'chore(release):')"
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v6
@@ -83,5 +84,25 @@ jobs:
       - name: Run standard-version
         run: npx standard-version --release-as ${{ steps.bump.outputs.type }}
 
-      - name: Push changes and tags
-        run: git push --follow-tags origin main
+      - name: Push release branch and tag
+        id: release
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          BRANCH="release/v${VERSION}"
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH" "v${VERSION}"
+
+      - name: Create release PR
+        run: |
+          VERSION="${{ steps.release.outputs.version }}"
+          BRANCH="release/v${VERSION}"
+          gh pr create \
+            --title "chore(release): v${VERSION}" \
+            --body "Automated version bump to v${VERSION}" \
+            --base main \
+            --head "$BRANCH"
+          # Auto-merge once CI passes (requires repo auto-merge setting)
+          gh pr merge "$BRANCH" --auto --squash || echo "Auto-merge not available, PR requires manual merge"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release workflow was failing because main is protected and requires
PRs with passing status checks. Instead of pushing directly to main,
the workflow now creates a release branch and PR that goes through the
normal CI pipeline. Also uses squash auto-merge to keep the process
automated, and updates the loop guard to use contains() so it catches
chore(release) in merge commit messages too.

https://claude.ai/code/session_01Xdfm1nXHNBDJ4XojDjtBrt