### PR TITLE
feat: post approval gate, dry-run, and m/dreams submolt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.3](https://github.com/RogueCtrl/OpenClawDreams/compare/v1.2.2...v1.2.3) (2026-03-07)
+
+### Features
+
+* **cli:** add `--dry-run` flag to `post` command ([#7](https://github.com/RogueCtrl/OpenClawDreams/pull/7))
+* **config:** add `requireApprovalBeforePost` option (default: `true`) to gate automatic posts ([#7](https://github.com/RogueCtrl/OpenClawDreams/pull/7))
+* **config:** add `dreamSubmolt` option (default: `"dreams"`) to configure target submolt ([#7](https://github.com/RogueCtrl/OpenClawDreams/pull/7))
+* **scheduler:** implement operator approval gate for morning dream posts via system events ([#7](https://github.com/RogueCtrl/OpenClawDreams/pull/7))
+
 ### [1.2.2](https://github.com/RogueCtrl/OpenClawDreams/compare/v1.2.1...v1.2.2) (2026-03-07)
 
 ### [1.2.1](https://github.com/RogueCtrl/OpenClawDreams/compare/v1.1.0...v1.2.1) (2026-03-07)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Once installed, configure the extension in your OpenClaw config (`config.json` o
           notificationChannel: "telegram", // Channel to notify operator (telegram, discord, slack, etc.)
           notifyOperatorOnDream: true,     // Send "I had a dream..." message
 
+          // Approval gate
+          requireApprovalBeforePost: true, // If true, operator must manually 'post' dreams
+          dreamSubmolt: "dreams",         // Submolt to post dreams to (default: dreams)
+
           // Optional
           // dataDir: "/custom/path"        — defaults to ./data
           // dreamEncryptionKey: "base64..." — auto-generated on first run
@@ -179,6 +183,8 @@ Once installed, configure the extension in your OpenClaw config (`config.json` o
 | `webSearchEnabled` | boolean | **true** | Enable web search for context gathering |
 | `notificationChannel` | string | "" | Channel to notify operator (telegram, discord, slack, etc.) |
 | `notifyOperatorOnDream` | boolean | **true** | Send "I had a dream" message to operator |
+| `requireApprovalBeforePost` | boolean | **true** | Wait for manual `post` instead of auto-publishing |
+| `dreamSubmolt` | string | "dreams" | Submolt for dream posts |
 | `postFilterEnabled` | boolean | true | Enable content filter for outbound posts (Moltbook only) |
 
 ### Verify
@@ -231,6 +237,7 @@ OpenClawDreams includes CLI commands for both inspecting agent state and manuall
 openclaw openclawdreams reflect   # Run a reflection cycle now (analyze conversations, synthesize insights)
 openclaw openclawdreams dream     # Run a dream cycle now (consolidate memories into a dream narrative)
 openclaw openclawdreams post      # Post latest dream to Moltbook (requires moltbookEnabled)
+openclaw openclawdreams post -d   # Dry run: see what would be posted without publishing
 ```
 
 These resolve your Anthropic API key from OpenClaw's auth profiles automatically and call the Anthropic API directly — no daemon gateway required.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -288,10 +288,47 @@ export function registerCommands(parent: Command): void {
     .description(
       "Manually trigger a Moltbook post from the latest dream (requires moltbookEnabled)"
     )
-    .action(async () => {
-      console.log(chalk.blue.bold("\nTriggering Moltbook post...\n"));
-      const { postDreamJournal, loadLatestDream } = await import("./dreamer.js");
+    .option("-d, --dry-run", "Show what would be posted without calling Moltbook API")
+    .action(async (opts: { dryRun?: boolean }) => {
+      const { postDreamJournal, loadLatestDream, deriveSlug } = await import(
+        "./dreamer.js"
+      );
+      const { reflectOnDreamJournal } = await import("./reflection.js");
+      const { applyFilter } = await import("./filter.js");
+      const { getDreamSubmolt } = await import("./config.js");
       const { client } = await createDirectClient();
+
+      if (opts.dryRun) {
+        console.log(chalk.yellow.bold("\n--- DRY RUN: Moltbook Post ---\n"));
+        const dream = loadLatestDream();
+        if (!dream) {
+          console.log(chalk.red("No dreams found to post."));
+          return;
+        }
+
+        const reflection = await reflectOnDreamJournal(client, dream);
+        const postContent = reflection?.synthesis ?? dream.markdown;
+        const slug = deriveSlug(dream.markdown);
+        const postTitle = reflection
+          ? `Morning Reflection: ${slug}`
+          : `Dream Journal: ${slug}`;
+
+        const filteredContent = await applyFilter(client, postContent, "post");
+        if (filteredContent === null) {
+          console.log(chalk.red("Post would be BLOCKED by filter."));
+          return;
+        }
+
+        const submolt = getDreamSubmolt();
+        console.log(`${chalk.bold("Submolt:")} m/${submolt}`);
+        console.log(`${chalk.bold("Title:")} ${postTitle}`);
+        console.log(`${chalk.bold("Content Preview:")}`);
+        console.log(chalk.dim(filteredContent.slice(0, 500) + "..."));
+        console.log(chalk.yellow.bold("\n--- END DRY RUN ---\n"));
+        return;
+      }
+
+      console.log(chalk.blue.bold("\nTriggering Moltbook post...\n"));
 
       // Show what will be posted
       const latestDream = loadLatestDream();

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,9 @@ let _notifyOperatorOnDream =
   (process.env.NOTIFY_OPERATOR_ON_DREAM ?? "true").toLowerCase() !== "false";
 let _postFilterEnabled =
   (process.env.POST_FILTER_ENABLED ?? "true").toLowerCase() !== "false";
+let _requireApprovalBeforePost =
+  (process.env.REQUIRE_APPROVAL_BEFORE_POST ?? "true").toLowerCase() !== "false";
+let _dreamSubmolt = process.env.DREAM_SUBMOLT ?? "dreams";
 
 /** Apply config values passed from the OpenClaw plugin API (`api.pluginConfig`). */
 export function applyPluginConfig(cfg: Record<string, unknown>): void {
@@ -58,6 +61,9 @@ export function applyPluginConfig(cfg: Record<string, unknown>): void {
     _notifyOperatorOnDream = cfg.notifyOperatorOnDream;
   if (typeof cfg.postFilterEnabled === "boolean")
     _postFilterEnabled = cfg.postFilterEnabled;
+  if (typeof cfg.requireApprovalBeforePost === "boolean")
+    _requireApprovalBeforePost = cfg.requireApprovalBeforePost;
+  if (typeof cfg.dreamSubmolt === "string") _dreamSubmolt = cfg.dreamSubmolt;
 }
 
 export const getMoltbookEnabled = (): boolean => _moltbookEnabled;
@@ -65,6 +71,8 @@ export const getWebSearchEnabled = (): boolean => _webSearchEnabled;
 export const getNotificationChannel = (): string => _notificationChannel;
 export const getNotifyOperatorOnDream = (): boolean => _notifyOperatorOnDream;
 export const getPostFilterEnabled = (): boolean => _postFilterEnabled;
+export const getRequireApprovalBeforePost = (): boolean => _requireApprovalBeforePost;
+export const getDreamSubmolt = (): string => _dreamSubmolt;
 
 // Legacy constant aliases — kept for backward compatibility but now delegate to
 // getters so they remain in sync after `applyPluginConfig()` is called.

--- a/src/dreamer.ts
+++ b/src/dreamer.ts
@@ -13,6 +13,7 @@ import {
   MAX_TOKENS_CONSOLIDATION,
   DREAM_TITLE_MAX_LENGTH,
   getMoltbookEnabled,
+  getDreamSubmolt,
 } from "./config.js";
 import { MoltbookClient } from "./moltbook.js";
 import { retrieveUndreamedMemories, markAsDreamed, deepMemoryStats } from "./memory.js";
@@ -95,7 +96,7 @@ async function consolidateDream(client: LLMClient, dream: Dream): Promise<string
 /**
  * Derive a short filesystem-safe name from the first line of the dream markdown.
  */
-function deriveSlug(markdown: string): string {
+export function deriveSlug(markdown: string): string {
   const firstLine = markdown.split("\n")[0] ?? "";
   const cleaned = firstLine
     .replace(/^#+\s*/, "")
@@ -285,8 +286,9 @@ export async function postDreamJournal(
   const safeTitle = postTitle.slice(0, 300);
 
   try {
-    await moltbook.createPost(safeTitle, contentWithFooter, "general");
-    logger.info(`Dream journal posted: ${safeTitle}`);
+    const submolt = getDreamSubmolt();
+    await moltbook.createPost(safeTitle, contentWithFooter, submolt);
+    logger.info(`Dream journal posted: ${safeTitle} in m/${submolt}`);
   } catch (e) {
     logger.error(`Failed to post dream journal: ${e}`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,19 @@
 
 import { registerCommands } from "./cli.js";
 import { runReflectionCycle } from "./waking.js";
-import { runDreamCycle, postDreamJournal } from "./dreamer.js";
+import { runDreamCycle, postDreamJournal, loadLatestDream, deriveSlug } from "./dreamer.js";
 import { deepMemoryStats, remember } from "./memory.js";
 import { loadState } from "./state.js";
 import { withBudget } from "./budget.js";
 import { setWorkspaceDir } from "./identity.js";
-import { getMoltbookEnabled, applyPluginConfig } from "./config.js";
+import {
+  getMoltbookEnabled,
+  applyPluginConfig,
+  getRequireApprovalBeforePost,
+} from "./config.js";
 import logger from "./logger.js";
 import type { LLMClient, OpenClawAPI } from "./types.js";
+import { execSync } from "node:child_process";
 
 // Store reference to OpenClaw API for use by other modules
 let openclawApi: OpenClawAPI | null = null;
@@ -423,7 +428,21 @@ export function register(api: OpenClawAPI): void {
     },
     7: async () => {
       if (getMoltbookEnabled()) {
-        await postDreamJournal(client);
+        if (getRequireApprovalBeforePost()) {
+          const dream = loadLatestDream();
+          const title = dream ? deriveSlug(dream.markdown) : "Latest Dream";
+          const msg = `Dream ready to post: ${title} — run 'openclawdreams post' to publish or 'openclawdreams post --dry-run' to preview`;
+          try {
+            execSync(`openclaw system event --text "${msg}" --mode now`, {
+              stdio: "inherit",
+            });
+            logger.info(`[ElectricSheep] Posted system event: ${msg}`);
+          } catch (err) {
+            logger.error(`[ElectricSheep] Failed to post system event: ${err}`);
+          }
+        } else {
+          await postDreamJournal(client);
+        }
       }
     },
     8: async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,4 +193,6 @@ export interface ElectricSheepConfig {
   webSearchEnabled: boolean;
   notificationChannel: string;
   notifyOperatorOnDream: boolean;
+  requireApprovalBeforePost: boolean;
+  dreamSubmolt: string;
 }


### PR DESCRIPTION
Implement --dry-run flag for post command, requireApprovalBeforePost config option (default: true) to gate automatic posts, and configurable dreamSubmolt (defaulting to m/dreams).