### PR TITLE
fix: DST-safe scheduler with catch-up window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclawdreams",
-  "version": "1.2.0",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclawdreams",
-      "version": "1.2.0",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,7 @@ export const NOTIFY_OPERATOR_ON_DREAM = true; // overridden by getter; prefer ge
 // Memory
 export const DEEP_MEMORY_DB = resolve(MEMORY_DIR, "deep.db");
 export const STATE_FILE = resolve(MEMORY_DIR, "state.json");
+export const SCHEDULER_STATE_FILE = resolve(DATA_DIR, "scheduler-state.json");
 
 // Token budget — $20/day using Opus 4.5 output rate ($25/1M) ≈ 800,000 tokens
 // Input tokens are $5/1M but we count all tokens against the output rate for simplicity.

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,16 +20,40 @@ import {
   getMoltbookEnabled,
   applyPluginConfig,
   getRequireApprovalBeforePost,
+  SCHEDULER_STATE_FILE,
 } from "./config.js";
 import logger from "./logger.js";
-import type { LLMClient, OpenClawAPI } from "./types.js";
+import type { LLMClient, OpenClawAPI, SchedulerState } from "./types.js";
 import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
 
 // Store reference to OpenClaw API for use by other modules
 let openclawApi: OpenClawAPI | null = null;
 
 export function getOpenClawAPI(): OpenClawAPI | null {
   return openclawApi;
+}
+
+/**
+ * Persist scheduler state to survive restarts.
+ */
+function loadSchedulerState(): SchedulerState {
+  if (existsSync(SCHEDULER_STATE_FILE)) {
+    try {
+      return JSON.parse(readFileSync(SCHEDULER_STATE_FILE, "utf-8"));
+    } catch {
+      return { last_ran: {} };
+    }
+  }
+  return { last_ran: {} };
+}
+
+function saveSchedulerState(state: SchedulerState): void {
+  try {
+    writeFileSync(SCHEDULER_STATE_FILE, JSON.stringify(state, null, 2));
+  } catch (err) {
+    logger.error(`[ElectricSheep] Failed to save scheduler state: ${err}`);
+  }
 }
 
 /**
@@ -425,7 +449,6 @@ export function register(api: OpenClawAPI): void {
   // Schedules: reflection @ 8,12,16,20h | dream @ 2h | journal @ 7h (local time)
 
   let _schedulerTimer: ReturnType<typeof setInterval> | null = null;
-  let _lastRanHour = -1;
 
   const SCHEDULE: Record<number, () => Promise<void>> = {
     2: async () => {
@@ -467,18 +490,53 @@ export function register(api: OpenClawAPI): void {
   api.registerService({
     id: "openclawdreams-scheduler",
     start: () => {
-      _lastRanHour = -1;
+      const state = loadSchedulerState();
       _schedulerTimer = setInterval(() => {
         void (async () => {
-          const hour = new Date().getHours();
-          if (hour !== _lastRanHour && SCHEDULE[hour]) {
-            _lastRanHour = hour;
-            try {
-              await SCHEDULE[hour]();
-            } catch (err) {
-              api.logger?.warn?.(
-                `[ElectricSheep] scheduled job hour=${hour} failed: ${err}`
-              );
+          const now = new Date();
+          // Use local date string (YYYY-MM-DD) for tracking "already ran today"
+          const todayStr = now.toLocaleDateString("en-CA");
+
+          for (const hourStr of Object.keys(SCHEDULE)) {
+            const scheduledHour = parseInt(hourStr, 10);
+
+            // Skip if already ran today for this hour
+            if (state.last_ran[scheduledHour] === todayStr) {
+              continue;
+            }
+
+            // Target time for today in local time
+            const target = new Date(
+              now.getFullYear(),
+              now.getMonth(),
+              now.getDate(),
+              scheduledHour,
+              0,
+              0
+            );
+
+            const diffMs = now.getTime() - target.getTime();
+            const ninetyMinutesMs = 90 * 60 * 1000;
+
+            // Catch-up logic: run if target has passed AND it's within the window (90m)
+            // This safely handles DST jumps (e.g. 1:59 -> 3:00) where the 2am hour is skipped.
+            if (diffMs >= 0 && diffMs <= ninetyMinutesMs) {
+              state.last_ran[scheduledHour] = todayStr;
+              saveSchedulerState(state);
+
+              try {
+                const lateMins = Math.round(diffMs / 60000);
+                logger.info(
+                  `[ElectricSheep] Running job hour=${scheduledHour}${
+                    lateMins > 1 ? ` (catch-up: ${lateMins}m late)` : ""
+                  }`
+                );
+                await SCHEDULE[scheduledHour]();
+              } catch (err) {
+                api.logger?.warn?.(
+                  `[ElectricSheep] scheduled job hour=${scheduledHour} failed: ${err}`
+                );
+              }
             }
           }
         })();

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,11 @@ export interface AgentState {
   [key: string]: unknown;
 }
 
+export interface SchedulerState {
+  /** Map of hour (0-23) to ISO date string (YYYY-MM-DD) of the last successful run. */
+  last_ran: Record<number, string>;
+}
+
 export interface TokenUsage {
   input_tokens: number;
   output_tokens: number;


### PR DESCRIPTION
## Problem
On DST spring-forward days (e.g. March 8 2026), local clocks jump from 1:59am → 3:00am. The scheduler used `new Date().getHours()` which meant the hour `2` never existed locally — silently skipping the 2am dream cycle and its operator notification.

## Fix
- Replaced the raw hour comparison with a **catch-up / window-based approach**
- Tracks last-run per job as `Map<hour, YYYY-MM-DD>` persisted to `data/scheduler-state.json`
- On each 60s tick, fires any scheduled job whose window has passed today (≤ 90 min late) and hasn't already run today
- DST gaps and brief restarts will now trigger a catch-up run rather than a silent skip

## Test
Build passes. Scheduler state survives restarts via disk persistence.