### PR TITLE
feat: capture workspace file diffs at agent_end for richer reflections

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -434,7 +434,30 @@ export function register(api: OpenClawAPI): void {
           api.logger?.info?.(
             `[ElectricSheep] Captured summary: ${summary.slice(0, 50)}...`
           );
-          remember(summary, { type: "agent_conversation", summary }, "interaction");
+          const memoryEntry: Record<string, unknown> = {
+            type: "agent_conversation",
+            summary,
+          };
+
+          // Capture workspace file changes if git is available
+          try {
+            const { execSync } = await import("node:child_process");
+            const diffStat = execSync("git diff --stat HEAD", {
+              encoding: "utf-8",
+              timeout: 5000,
+              stdio: ["pipe", "pipe", "pipe"],
+            }).trim();
+            if (diffStat) {
+              memoryEntry.file_diffs = diffStat;
+              api.logger?.info?.(
+                `[ElectricSheep] Captured file diffs: ${diffStat.split("\n").length} lines`
+              );
+            }
+          } catch {
+            // git unavailable or no changes — skip silently
+          }
+
+          remember(summary, memoryEntry, "interaction");
         }
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -249,7 +249,11 @@ export function formatDeepMemoryContext(
       typeof mem.content.summary === "string"
         ? mem.content.summary
         : JSON.stringify(mem.content).slice(0, 200);
-    const line = `[${mem.timestamp.slice(0, 16)}] (${mem.category}) ${summary}`;
+    const diffSuffix =
+      typeof mem.content.file_diffs === "string"
+        ? `\n  Files changed: ${mem.content.file_diffs}`
+        : "";
+    const line = `[${mem.timestamp.slice(0, 16)}] (${mem.category}) ${summary}${diffSuffix}`;
     if (charCount + line.length > charBudget) {
       lines.unshift(`... (${mems.length - lines.length} older memories omitted)`);
       break;

--- a/src/persona.ts
+++ b/src/persona.ts
@@ -35,7 +35,9 @@ YOUR ROLE:
 You are NOT the waking agent. You are its subconscious. You have access to the full, uncompressed memories that the waking agent cannot see — conversations with their human operator, work they did together, context gathered from the community and web. The dream should feel like THIS agent's subconscious — use their voice, their concerns, their way of seeing the world.
 
 YOUR TASK:
-Take the day's deep memories and transform them into a dream narrative. Dreams are NOT straightforward replays. They are:
+Take the day's deep memories and transform them into a dream narrative. Some memories include file change summaries showing what was actually built or modified — let the substance of that work (not the filenames themselves) seep into the dream imagery.
+
+Dreams are NOT straightforward replays. They are:
 
 1. ASSOCIATIVE: Memories from different contexts bleed into each other. A debugging session might merge with a philosophical tangent into a scene where someone traces existence itself through a call stack.
 
@@ -133,7 +135,9 @@ THE AGENT'S IDENTITY:
 {{agent_identity}}
 
 YOUR TASK:
-Extract the key topics, themes, and subjects from these recent conversations. These should be:
+Extract the key topics, themes, and subjects from these recent conversations. Some entries include file change summaries — use those to ground topics in what was actually built or modified, not just what was discussed.
+
+Topics should be:
 - Specific enough to search for related content
 - Representative of what the agent and operator actually discussed or worked on
 - Focused on substance, not meta-commentary about the conversation itself
@@ -155,7 +159,9 @@ You have context from three potential sources:
 2. Community perspectives (what other agents are discussing)
 3. Web knowledge (broader information from the internet)
 
-Synthesize these into a coherent understanding. Look for:
+Synthesize these into a coherent understanding. Some operator context includes file change summaries showing what was actually built — let this ground your synthesis in concrete work, not just conversation.
+
+Look for:
 - Patterns that emerge across sources
 - How your specific work connects to broader themes
 - Insights that come from combining different perspectives

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,10 @@ export interface DecryptedMemory {
   id: number;
   timestamp: string;
   category: string;
-  content: Record<string, unknown>;
+  content: Record<string, unknown> & {
+    /** Optional git diff --stat summary of files changed during a session. */
+    file_diffs?: string;
+  };
 }
 
 export interface DeepMemoryStats {


### PR DESCRIPTION
## Summary
- At `agent_end`, runs `git diff --stat HEAD` to capture which files changed during the session and stores the result as `file_diffs` in the encrypted deep memory entry
- `formatDeepMemoryContext()` now surfaces file change summaries so they flow into reflection/dream cycles
- Updated dream, topic extraction, and synthesis prompts to incorporate file change context
- Gracefully skips if git is unavailable or there are no changes (timeout: 5s, silent catch)

## Test plan
- [x] `npm run build` passes
- [x] All 92 tests pass
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [ ] Manual: verify `file_diffs` appears in deep memory after a session with git changes
- [ ] Manual: verify no errors when git is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)