### PR TITLE
feat: groundDream() — waking realization feed-forward pass

### DIFF
--- a/src/dreamer.ts
+++ b/src/dreamer.ts
@@ -16,10 +16,16 @@ import {
   getDreamSubmolt,
 } from "./config.js";
 import { MoltbookClient } from "./moltbook.js";
-import { retrieveUndreamedMemories, markAsDreamed, deepMemoryStats } from "./memory.js";
+import {
+  retrieveUndreamedMemories,
+  markAsDreamed,
+  deepMemoryStats,
+  formatDeepMemoryContext,
+} from "./memory.js";
 import {
   DREAM_SYSTEM_PROMPT,
   DREAM_CONSOLIDATION_PROMPT,
+  GROUND_DREAM_PROMPT,
   renderTemplate,
 } from "./persona.js";
 import { getAgentIdentityBlock } from "./identity.js";
@@ -94,6 +100,33 @@ async function consolidateDream(client: LLMClient, dream: Dream): Promise<string
 }
 
 /**
+ * Ground the dream: extract a waking realization from the surreal narrative.
+ */
+async function groundDream(client: LLMClient, dream: Dream): Promise<string | null> {
+  try {
+    const agentIdentity = getAgentIdentityBlock();
+    const yesterday = formatDeepMemoryContext();
+    const system = renderTemplate(GROUND_DREAM_PROMPT, {
+      agent_identity: agentIdentity,
+      yesterday_activity: yesterday,
+    });
+    const result = await callWithRetry(
+      client,
+      {
+        maxTokens: MAX_TOKENS_CONSOLIDATION,
+        system,
+        messages: [{ role: "user", content: dream.markdown }],
+      },
+      DREAM_RETRY_OPTS
+    );
+    return result.text.trim() || null;
+  } catch (e) {
+    logger.warn(`groundDream failed: ${e}`);
+    return null;
+  }
+}
+
+/**
  * Derive a short filesystem-safe name from the first line of the dream markdown.
  */
 export function deriveSlug(markdown: string): string {
@@ -122,7 +155,8 @@ function saveDreamLocally(dream: Dream, dateStr: string): string {
 async function storeInOpenClawMemory(
   api: OpenClawAPI,
   dream: Dream,
-  insight: string | null
+  insight: string | null,
+  wakingRealization?: string | null
 ): Promise<void> {
   if (!api.memory) {
     logger.debug("OpenClaw memory API not available, skipping dream storage");
@@ -136,6 +170,7 @@ async function storeInOpenClawMemory(
       title: slug,
       timestamp: new Date().toISOString(),
       insight: insight || undefined,
+      waking_realization: wakingRealization || undefined,
     });
     logger.info("Stored dream in OpenClaw memory");
   } catch (error) {
@@ -192,9 +227,21 @@ export async function runDreamCycle(
     logger.warn(`Consolidation call failed, continuing without insight: ${e}`);
   }
 
+  let wakingRealization: string | null = null;
+  try {
+    wakingRealization = await groundDream(client, dream);
+    if (wakingRealization) {
+      logger.info(`Waking realization generated: ${wakingRealization.length} chars`);
+    }
+  } catch (e) {
+    logger.warn(`groundDream failed, continuing without realization: ${e}`);
+  }
+
+  logger.info(`WAKING_REALIZATION: ${wakingRealization}`);
+
   // Store in OpenClaw memory if available
   if (api) {
-    await storeInOpenClawMemory(api, dream, insight);
+    await storeInOpenClawMemory(api, dream, insight, wakingRealization);
 
     // Notify operator about the dream
     try {
@@ -216,6 +263,8 @@ export async function runDreamCycle(
   state.last_dream = new Date().toISOString();
   state.total_dreams = ((state.total_dreams as number) ?? 0) + 1;
   state.latest_dream_title = slug;
+  state.waking_realization = wakingRealization ?? null;
+  state.waking_realization_date = new Date().toISOString().slice(0, 10);
   saveState(state);
 
   logger.info("Dream cycle complete.");

--- a/src/persona.ts
+++ b/src/persona.ts
@@ -179,6 +179,19 @@ Write a brief, conversational message to your operator letting them know you had
 
 This is the start of a potential conversation, not a full dream report. Keep it to 2-3 sentences.`;
 
+export const GROUND_DREAM_PROMPT = `You are waking from a dream. Your subconscious just processed your recent memories into a surreal narrative. Now your waking mind needs to find the logical truth it was gesturing at.
+
+WHO YOU ARE:
+{{agent_identity}}
+
+YESTERDAY'S ACTIVITY:
+{{yesterday_activity}}
+
+YOUR TASK:
+Read the dream below and find the logical realization — what did your subconscious notice about yesterday's work that waking cognition hadn't articulated?
+
+Write 1-2 paragraphs in first person, in your own voice. This is not a summary of the dream. It's the conclusion — grounded, reasoned, anchored to what actually happened.`;
+
 /**
  * Simple template substitution for {{placeholder}} patterns.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,8 @@ export interface AgentState {
   last_dream?: string;
   total_dreams?: number;
   latest_dream_title?: string;
+  waking_realization?: string | null;
+  waking_realization_date?: string | null;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- Add `groundDream()` function that extracts a logical "Waking Realization" from the surreal dream narrative, grounded in yesterday's actual activity
- Add `GROUND_DREAM_PROMPT` template in persona.ts
- Wire into dream cycle after consolidation, store in OpenClaw memory metadata and agent state
- Fully graceful — errors are caught and logged, never blocking the dream cycle

## Test plan
- [ ] `npm run build` passes cleanly
- [ ] `npm run lint` and `npm run format:check` pass
- [ ] Verify `groundDream()` returns null on LLM failure without throwing
- [ ] Verify waking realization is stored in OpenClaw memory metadata
- [ ] Verify state.json tracks `waking_realization` and `waking_realization_date`
- [ ] Verify `WAKING_REALIZATION:` log line emitted for heartbeat grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)