### PR TITLE
fix: run tests sequentially to prevent env var race condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/bin/openclawdreams.js",
-    "test": "node --import tsx --test 'test/**/*.test.ts'",
+    "test": "node --import tsx --test --test-concurrency=1 'test/**/*.test.ts'",
     "lint": "eslint 'src/**/*.ts' 'test/**/*.ts' 'bin/**/*.ts'",
     "lint:fix": "eslint --fix 'src/**/*.ts' 'test/**/*.ts' 'bin/**/*.ts'",
     "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts' 'bin/**/*.ts'",


### PR DESCRIPTION
All test files set `process.env.OPENCLAWDREAMS_DATA_DIR` at module level. Node's test runner executes files in parallel by default, so they clobber each other's data dir mid-run. The addition of `nightmare.test.ts` in v1.4.0 tipped the balance — `budget.test` and `moltbook.test` started failing intermittently.\n\nFix: add `--test-concurrency=1` to the test script. Tests now run sequentially; all 96 pass.