### PR TITLE
feat: reflect --dry-run — print synthesis output without storing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -281,12 +281,18 @@ export function registerCommands(parent: Command): void {
   parent
     .command("reflect")
     .description("Manually trigger the reflection and synthesis cycle")
-    .action(async () => {
-      console.log(chalk.cyan.bold("\nTriggering reflection cycle...\n"));
+    .option("--dry-run", "Print synthesis output without storing to memory")
+    .action(async (opts: { dryRun?: boolean }) => {
+      const dryRun = opts.dryRun ?? false;
+      if (dryRun) {
+        console.log(chalk.cyan.bold("\nTriggering reflection cycle (dry run)...\n"));
+      } else {
+        console.log(chalk.cyan.bold("\nTriggering reflection cycle...\n"));
+      }
       const { runReflectionCycle } = await import("./waking.js");
       const { client, api } = await createDirectClient();
       try {
-        await runReflectionCycle(client, api);
+        await runReflectionCycle(client, api, { dryRun });
         console.log(chalk.green.bold("\nReflection cycle complete.\n"));
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/src/waking.ts
+++ b/src/waking.ts
@@ -87,21 +87,26 @@ async function storeInOpenClawMemory(
  */
 export async function runReflectionCycle(
   client: LLMClient,
-  api: OpenClawAPI
+  api: OpenClawAPI,
+  options?: { dryRun?: boolean }
 ): Promise<void> {
+  const dryRun = options?.dryRun ?? false;
   logger.info("ElectricSheep reflection cycle starting");
 
   // Check if we have any conversations to reflect on
   const recentConversations = getRecentConversations();
   if (recentConversations.length === 0) {
     logger.info("No recent conversations to reflect on");
-    storeDeepMemory(
-      {
-        summary: "Reflection cycle ran but no recent operator conversations to process.",
-        type: "observation",
-      },
-      "observation"
-    );
+    if (!dryRun) {
+      storeDeepMemory(
+        {
+          summary:
+            "Reflection cycle ran but no recent operator conversations to process.",
+          type: "observation",
+        },
+        "observation"
+      );
+    }
     return;
   }
 
@@ -112,13 +117,15 @@ export async function runReflectionCycle(
 
   if (context.topics.length === 0) {
     logger.info("No topics extracted from conversations");
-    storeDeepMemory(
-      {
-        summary: "Analyzed recent conversations but no clear topics emerged.",
-        type: "observation",
-      },
-      "observation"
-    );
+    if (!dryRun) {
+      storeDeepMemory(
+        {
+          summary: "Analyzed recent conversations but no clear topics emerged.",
+          type: "observation",
+        },
+        "observation"
+      );
+    }
     return;
   }
 
@@ -134,6 +141,16 @@ export async function runReflectionCycle(
 
   // Store in local memory systems
   const summary = await summarizeSynthesis(client, synthesis, context.topics);
+
+  if (dryRun) {
+    // Print synthesis output instead of storing
+    console.log("\n--- DRY RUN: Reflection Synthesis ---\n");
+    console.log(`Topics: ${context.topics.join(", ")}\n`);
+    console.log(synthesis);
+    console.log(`\nSummary: ${summary}`);
+    console.log("\n--- End Dry Run ---\n");
+    return;
+  }
 
   // Store full context in deep memory (includes summary for later retrieval)
   storeDeepMemory(


### PR DESCRIPTION
## Summary
- Adds `--dry-run` flag to `openclawdreams reflect` CLI command
- Runs the full reflection pipeline (memory retrieval, topic extraction, synthesis) but prints output to stdout instead of encrypting/storing to memory
- Useful for debugging synthesis quality and tuning prompts without touching the memory store

## Test plan
- [x] `npm run build` compiles clean
- [x] `npm run lint` passes
- [x] `npm test` — all 100 tests pass
- [ ] Manual: `npx openclawdreams reflect --dry-run` prints synthesis without writing to deep.db

🤖 Generated with [Claude Code](https://claude.com/claude-code)