### PR TITLE
feat: dream entropy enforcement — overlap scoring + re-prompt on recycled territory

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,7 @@ let _dreamSubmolt = process.env.DREAM_SUBMOLT ?? "dreams";
 let _workspaceDiffEnabled =
   (process.env.WORKSPACE_DIFF_ENABLED ?? "true").toLowerCase() !== "false";
 let _metaLoopThreshold = parseInt(process.env.META_LOOP_THRESHOLD ?? "3", 10);
+let _entropyOverlapThreshold = parseFloat(process.env.ENTROPY_OVERLAP_THRESHOLD ?? "0.5");
 
 /** Apply config values passed from the OpenClaw plugin API (`api.pluginConfig`). */
 export function applyPluginConfig(cfg: Record<string, unknown>): void {
@@ -109,6 +110,8 @@ export function applyPluginConfig(cfg: Record<string, unknown>): void {
     _workspaceDiffEnabled = cfg.workspaceDiffEnabled;
   if (typeof cfg.metaLoopThreshold === "number")
     _metaLoopThreshold = cfg.metaLoopThreshold;
+  if (typeof cfg.entropyOverlapThreshold === "number")
+    _entropyOverlapThreshold = cfg.entropyOverlapThreshold;
 }
 
 export const getMoltbookEnabled = (): boolean => _moltbookEnabled;
@@ -120,6 +123,7 @@ export const getRequireApprovalBeforePost = (): boolean => _requireApprovalBefor
 export const getDreamSubmolt = (): string => _dreamSubmolt;
 export const getWorkspaceDiffEnabled = (): boolean => _workspaceDiffEnabled;
 export const getMetaLoopThreshold = (): number => _metaLoopThreshold;
+export const getEntropyOverlapThreshold = (): number => _entropyOverlapThreshold;
 
 // Legacy constant aliases — kept for backward compatibility but now delegate to
 // getters so they remain in sync after `applyPluginConfig()` is called.

--- a/src/dreamer.ts
+++ b/src/dreamer.ts
@@ -21,7 +21,9 @@ import {
   DREAM_TITLE_MAX_LENGTH,
   getMoltbookEnabled,
   getDreamSubmolt,
+  getEntropyOverlapThreshold,
 } from "./config.js";
+import { extractConcepts, computeOverlap, getOverlappingConcepts } from "./entropy.js";
 import { MoltbookClient } from "./moltbook.js";
 import { getSteeringDirective } from "./meta-loop.js";
 import {
@@ -82,7 +84,8 @@ export async function generateDream(
   client: LLMClient,
   memories: DecryptedMemory[],
   exploredTerritory: string,
-  isNightmare: boolean = false
+  isNightmare: boolean = false,
+  hardConstraint?: string
 ): Promise<Dream> {
   const formatted = memories.map(
     (mem) =>
@@ -98,6 +101,10 @@ export async function generateDream(
       explored_territory: exploredTerritory,
     }) + getSteeringDirective();
 
+  const baseUserPrompt = isNightmare
+    ? "Process these memories into a nightmare. Be fractured and wrong."
+    : "Process these memories into a dream. Be surreal, associative, and emotionally amplified.";
+
   const { text } = await callWithRetry(
     client,
     {
@@ -106,9 +113,9 @@ export async function generateDream(
       messages: [
         {
           role: "user",
-          content: isNightmare
-            ? "Process these memories into a nightmare. Be fractured and wrong."
-            : "Process these memories into a dream. Be surreal, associative, and emotionally amplified.",
+          content: hardConstraint
+            ? `${baseUserPrompt}\n\n${hardConstraint}`
+            : baseUserPrompt,
         },
       ],
     },
@@ -351,6 +358,38 @@ export async function runDreamCycle(
 
   // Generate new dream from current memories
   let dream = await generateDream(client, memories, exploredTerritory, isNightmare);
+
+  // ─── Entropy Enforcement ──────────────────────────────────────────────────
+  const concepts = extractConcepts(dream.markdown);
+  const overlapScore = computeOverlap(concepts, pastRealizations);
+  const threshold = getEntropyOverlapThreshold();
+
+  state.entropy_last_overlap = overlapScore;
+
+  if (overlapScore > threshold) {
+    const overlapping = getOverlappingConcepts(concepts, pastRealizations);
+    logger.warn(
+      `[entropy] overlap=${overlapScore.toFixed(
+        2
+      )}, threshold=${threshold} — dream recycling explored territory, re-prompting`
+    );
+
+    const hardConstraint = `HARD CONSTRAINT: Your previous draft recycled ${Math.round(
+      overlapScore * 100
+    )}% of already-explored territory. You MUST explore genuinely new ground. Forbidden concepts from prior realizations: [${overlapping.join(
+      ", "
+    )}]. Do not revisit these themes. Find something entirely new.`;
+
+    dream = await generateDream(
+      client,
+      memories,
+      exploredTerritory,
+      isNightmare,
+      hardConstraint
+    );
+    state.entropy_reprompt_count = ((state.entropy_reprompt_count as number) ?? 0) + 1;
+  }
+  // ──────────────────────────────────────────────────────────────────────────
 
   // If a remembrance was triggered, synthesize them into a single meta-dream
   if (rememberedDream) {

--- a/src/entropy.ts
+++ b/src/entropy.ts
@@ -1,0 +1,165 @@
+/**
+ * Entropy check utilities for detecting concept recycling.
+ */
+
+/**
+ * Tokenize text into lowercase words, strip punctuation, and remove stop words.
+ * Returns deduplicated words with at least 3 characters.
+ */
+export function extractConcepts(text: string): string[] {
+  const stopWords = new Set([
+    "a",
+    "an",
+    "the",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "being",
+    "have",
+    "has",
+    "had",
+    "do",
+    "does",
+    "did",
+    "will",
+    "would",
+    "could",
+    "should",
+    "may",
+    "might",
+    "must",
+    "shall",
+    "to",
+    "of",
+    "in",
+    "on",
+    "at",
+    "for",
+    "from",
+    "with",
+    "by",
+    "about",
+    "as",
+    "into",
+    "through",
+    "and",
+    "or",
+    "but",
+    "not",
+    "this",
+    "that",
+    "these",
+    "those",
+    "it",
+    "its",
+    "i",
+    "you",
+    "we",
+    "they",
+    "he",
+    "she",
+    "my",
+    "your",
+    "our",
+    "their",
+    "what",
+    "when",
+    "where",
+    "how",
+    "why",
+    "so",
+    "if",
+    "then",
+    "than",
+    "there",
+    "here",
+    "all",
+    "each",
+    "any",
+    "no",
+    "more",
+    "most",
+    "some",
+    "such",
+    "same",
+    "just",
+    "also",
+    "very",
+    "too",
+    "up",
+    "out",
+    "over",
+    "after",
+    "before",
+    "now",
+    "only",
+    "even",
+    "back",
+    "still",
+    "own",
+    "well",
+  ]);
+
+  if (!text) return [];
+
+  const words = text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .split(/\s+/)
+    .filter((word) => word.length >= 3 && !stopWords.has(word));
+
+  return [...new Set(words)];
+}
+
+/**
+ * Compute the overlap ratio (0.0 to 1.0) between current concepts and past realizations.
+ */
+export function computeOverlap(concepts: string[], pastRealizations: string[]): number {
+  if (concepts.length === 0 || !pastRealizations || pastRealizations.length === 0) {
+    return 0;
+  }
+
+  const pastConcepts = new Set<string>();
+  for (const realization of pastRealizations) {
+    const extracted = extractConcepts(realization);
+    for (const concept of extracted) {
+      pastConcepts.add(concept);
+    }
+  }
+
+  if (pastConcepts.size === 0) return 0;
+
+  let matchCount = 0;
+  for (const concept of concepts) {
+    if (pastConcepts.has(concept)) {
+      matchCount++;
+    }
+  }
+
+  return matchCount / concepts.length;
+}
+
+/**
+ * Identify which concepts from the current set already exist in past realizations.
+ */
+export function getOverlappingConcepts(
+  concepts: string[],
+  pastRealizations: string[]
+): string[] {
+  if (concepts.length === 0 || !pastRealizations || pastRealizations.length === 0) {
+    return [];
+  }
+
+  const pastConcepts = new Set<string>();
+  for (const realization of pastRealizations) {
+    const extracted = extractConcepts(realization);
+    for (const concept of extracted) {
+      pastConcepts.add(concept);
+    }
+  }
+
+  return concepts.filter((concept) => pastConcepts.has(concept));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,8 @@ export interface AgentState {
   dreams_backfilled?: boolean;
   last_reflection_topics?: string[];
   meta_loop_depth?: number;
+  entropy_last_overlap?: number;
+  entropy_reprompt_count?: number;
   [key: string]: unknown;
 }
 
@@ -244,4 +246,5 @@ export interface ElectricSheepConfig {
   notifyOperatorOnDream: boolean;
   requireApprovalBeforePost: boolean;
   dreamSubmolt: string;
+  entropyOverlapThreshold: number;
 }

--- a/test/entropy.test.ts
+++ b/test/entropy.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extractConcepts, computeOverlap } from "../src/entropy.js";
+import type { LLMClient } from "../src/types.js";
+
+// Setup for integration tests
+const testDir = mkdtempSync(join(tmpdir(), "es-entropy-test-"));
+process.env.OPENCLAWDREAMS_DATA_DIR = testDir;
+process.env.ENTROPY_OVERLAP_THRESHOLD = "0.5";
+
+const { runDreamCycle } = await import("../src/dreamer.js");
+const { storeDeepMemory, closeDb } = await import("../src/memory.js");
+const { loadState, saveState } = await import("../src/state.js");
+const { closeLogger } = await import("../src/logger.js");
+
+function mockLLMClient(responses: string[]): LLMClient {
+  let idx = 0;
+  return {
+    async createMessage() {
+      const text = responses[idx] ?? responses[responses.length - 1];
+      idx++;
+      return { text };
+    },
+  };
+}
+
+describe("Entropy utilities", () => {
+  describe("extractConcepts", () => {
+    it("returns meaningful words from typical dream text", () => {
+      const text =
+        "The recursive lobster is standing in a server room made of coral. The racks breathe.";
+      const concepts = extractConcepts(text);
+      // Expected: recursive, lobster, standing, server, room, made, coral, racks, breathe
+      assert.ok(concepts.includes("recursive"));
+      assert.ok(concepts.includes("lobster"));
+      assert.ok(concepts.includes("standing"));
+      assert.ok(concepts.includes("server"));
+      assert.ok(concepts.includes("room"));
+      assert.ok(concepts.includes("made"));
+      assert.ok(concepts.includes("coral"));
+      assert.ok(concepts.includes("racks"));
+      assert.ok(concepts.includes("breathe"));
+      // Stop words removed
+      assert.ok(!concepts.includes("the"));
+      assert.ok(!concepts.includes("is"));
+      assert.ok(!concepts.includes("in"));
+      assert.ok(!concepts.includes("a"));
+      assert.ok(!concepts.includes("of"));
+    });
+
+    it("strips punctuation and converts to lowercase", () => {
+      const text = "LOBSTER! (recursive) - coral.";
+      const concepts = extractConcepts(text);
+      assert.deepEqual(concepts.sort(), ["coral", "lobster", "recursive"]);
+    });
+
+    it("deduplicates words", () => {
+      const text = "lobster lobster coral coral";
+      const concepts = extractConcepts(text);
+      assert.deepEqual(concepts.sort(), ["coral", "lobster"]);
+    });
+
+    it("filters out words shorter than 3 characters", () => {
+      const text = "a it to ox coral";
+      const concepts = extractConcepts(text);
+      assert.deepEqual(concepts, ["coral"]);
+    });
+
+    it("returns empty array for empty string", () => {
+      assert.deepEqual(extractConcepts(""), []);
+    });
+  });
+
+  describe("computeOverlap", () => {
+    it("returns 0 for empty inputs", () => {
+      assert.equal(computeOverlap([], []), 0);
+      assert.equal(computeOverlap(["lobster"], []), 0);
+      assert.equal(computeOverlap([], ["past realization"]), 0);
+    });
+
+    it("returns correct ratio for known inputs (0.5)", () => {
+      const concepts = ["lobster", "coral", "server", "room"];
+      const past = ["The lobster is in the room."];
+      // Overlapping: lobster, room (2 of 4)
+      assert.equal(computeOverlap(concepts, past), 0.5);
+    });
+
+    it("returns 1.0 when all concepts overlap", () => {
+      const concepts = ["lobster", "coral"];
+      const past = ["A lobster made of coral."];
+      assert.equal(computeOverlap(concepts, past), 1.0);
+    });
+
+    it("handles past_realizations with multiple entries", () => {
+      const concepts = ["lobster", "coral", "server"];
+      assert.equal(computeOverlap(concepts, ["lobster", "coral"]), 2 / 3);
+    });
+  });
+});
+
+describe("Entropy integration", () => {
+  it("saves entropy_last_overlap to state after dream generation", async () => {
+    storeDeepMemory({ text: "memory 1" }, "interaction");
+    const client = mockLLMClient([
+      "# Dream\n\nLobster and coral.",
+      "insight",
+      "realization",
+    ]);
+
+    await runDreamCycle(client);
+
+    const state = loadState();
+    assert.notEqual(state.entropy_last_overlap, undefined);
+    assert.ok(typeof state.entropy_last_overlap === "number");
+  });
+
+  it("increments entropy_reprompt_count when overlap exceeds threshold", async () => {
+    storeDeepMemory({ text: "memory 2" }, "interaction");
+
+    const state = loadState();
+    state.past_realizations = ["lobster", "coral", "server"];
+    saveState(state);
+
+    // First draft overlaps completely: lobster, coral, server
+    const firstDraft = "# Dream\n\nLobster, coral, and server.";
+    // Second draft is different
+    const secondDraft = "# New Dream\n\nForest and mountains.";
+
+    // runDreamCycle calls:
+    // 1. generateDream (first draft)
+    // 2. generateDream (re-prompt)
+    // 3. consolidateDream
+    // 4. groundDream
+    const client = mockLLMClient([firstDraft, secondDraft, "insight", "realization"]);
+
+    await runDreamCycle(client);
+
+    const newState = loadState();
+    assert.equal(newState.entropy_reprompt_count, 1);
+    assert.equal(newState.entropy_last_overlap, 0.75); // "dream", "lobster", "coral", "server" -> 3/4 overlap
+  });
+});
+
+after(async () => {
+  closeDb();
+  await closeLogger();
+  rmSync(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});


### PR DESCRIPTION
## Summary

Adds an active entropy guard to dream generation. When a dream draft overlaps too heavily with already-explored conceptual territory (tracked in `past_realizations[]`), the system re-prompts with a hard constraint listing the forbidden concepts.

### Problem

`explored_territory` in the dream/reflect prompts is a *passive nudge* — the model sees it but can still drift back to familiar ground. The 2026-03-09 dream distillation surfaced this explicitly: *'past_realizations[] are stored but may be hollow — the system acknowledges them in the prompt but the generated output keeps re-arriving at the same core insight from a slightly different angle.'*

### Solution

- **`extractConcepts(text)`** — tokenize, strip stop-words, deduplicate (min 3 chars)
- **`computeOverlap(concepts, pastRealizations)`** — ratio of dream concepts that already appear in past realizations (0.0–1.0)
- **Entropy check in `dreamer.ts`** — after draft generation, if overlap > threshold: log warning, re-prompt with hard constraint listing the overlapping concepts, use second draft
- **`entropy_last_overlap`** — persisted to state.json after every dream cycle (observability)
- **`entropy_reprompt_count`** — cumulative counter of forced re-prompts
- **`entropyOverlapThreshold`** — configurable via `ENTROPY_OVERLAP_THRESHOLD` env or plugin config (default: 0.5)

### Changes

| File | What |
|------|------|
| `src/entropy.ts` | New module — concept extraction + overlap scoring |
| `src/types.ts` | `entropy_last_overlap`, `entropy_reprompt_count` added to AgentState |
| `src/config.ts` | `entropyOverlapThreshold` config + getter |
| `src/dreamer.ts` | Entropy check + conditional re-prompt after draft generation |
| `test/entropy.test.ts` | 12 new tests |

### Tests

125/125 passing (12 new). Build clean, lint clean.

### Relationship to PR #81

PR #81 (recursive reflection guard) operates on *reflection topics* — detects self-referential input. This PR operates on *dream output content* — detects when the generated text recycles explored ground. They're complementary guards at different pipeline stages.

---

*Motivated by the 2026-03-09 dream distillation: the insight effectiveness audit candidate that surfaced from 'The Architecture of Waking'.*