### PR TITLE
fix: extract dream title from first markdown heading, not first line

### DIFF
--- a/src/dreamer.ts
+++ b/src/dreamer.ts
@@ -220,12 +220,15 @@ export async function groundDream(
  * Derive a short filesystem-safe name from the first line of the dream markdown.
  */
 export function deriveSlug(markdown: string): string {
-  const firstLine = markdown.split("\n")[0] ?? "";
-  const cleaned = firstLine
-    .replace(/^#+\s*/, "")
-    .replace(/\*\*/g, "")
-    .trim();
-  const slug = (cleaned || "dream")
+  const lines = markdown.split("\n");
+  const headingLine = lines.find((line) => /^#+\s+/.test(line));
+  const raw = headingLine
+    ? headingLine
+        .replace(/^#+\s*/, "")
+        .replace(/\*\*/g, "")
+        .trim()
+    : "";
+  const slug = (raw || `dream-${new Date().toISOString().slice(0, 10)}`)
     .slice(0, DREAM_TITLE_MAX_LENGTH)
     .replace(/[\s/]/g, "_");
   return slug;

--- a/test/dreamer.test.ts
+++ b/test/dreamer.test.ts
@@ -9,7 +9,7 @@ const testDir = mkdtempSync(join(tmpdir(), "es-dreamer-test-"));
 process.env.OPENCLAWDREAMS_DATA_DIR = testDir;
 process.env.NIGHTMARE_CHANCE = "0";
 
-const { runDreamCycle } = await import("../src/dreamer.js");
+const { runDreamCycle, deriveSlug } = await import("../src/dreamer.js");
 const { storeDeepMemory, closeDb } = await import("../src/memory.js");
 const { loadState } = await import("../src/state.js");
 const { getDreamsDir } = await import("../src/config.js");
@@ -86,6 +86,25 @@ describe("Dream cycle", () => {
     const dream = await runDreamCycle(client);
     assert.ok(dream);
     assert.ok(dream.markdown.includes("A Quiet Night"));
+  });
+});
+
+describe("deriveSlug", () => {
+  it("extracts title from heading after preamble", () => {
+    const md =
+      "Let me think about this...\nSome reasoning here\n# The Coral Server\n\nDream body.";
+    assert.equal(deriveSlug(md), "The_Coral_Server");
+  });
+
+  it("extracts title from heading with no preamble", () => {
+    const md = "# Midnight Whispers\n\nThe circuits hum.";
+    assert.equal(deriveSlug(md), "Midnight_Whispers");
+  });
+
+  it("falls back to timestamp slug when no heading exists", () => {
+    const md = "Just some text with no heading at all.\nMore text.";
+    const slug = deriveSlug(md);
+    assert.match(slug, /^dream-\d{4}-\d{2}-\d{2}$/);
   });
 });
 


### PR DESCRIPTION
## Summary
- `deriveSlug()` was reading the first line of LLM output as the dream title, which could be model reasoning preamble instead of the actual `# Heading`
- Now scans for the first markdown heading (`# ...`) and extracts the title from it
- Falls back to a timestamp-based slug (`dream-YYYY-MM-DD`) if no heading is found
- Added 3 test cases: preamble before heading, heading with no preamble, no heading at all

Closes #91

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run build` passes
- [x] `npm test` — all 153 tests pass, including 3 new `deriveSlug` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)